### PR TITLE
assertColumnEquality reuses assertLargeDatasetEquality

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/ColumnComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/ColumnComparer.scala
@@ -58,13 +58,11 @@ trait ColumnComparer extends DatasetComparer {
       df,
       colName1,
       colName2,
-      equals = (r1: Row, r2: Row) => {
-        r1.equals(r2) || RowComparer.areRowsEqual(
-          r1,
-          r2,
-          precision
-        )
-      }
+      DatasetComparerLike.precisionEquality(
+        _,
+        _,
+        precision
+      )
     )
   }
 }

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -134,15 +134,18 @@ ${DataFramePrettyPrint.showString(
   def assertLargeDatasetEquality[T: ClassTag](
     actualDS: Dataset[T],
     expectedDS: Dataset[T],
-    equals: (T, T) => Boolean = naiveEquality _
+    equals: (T, T) => Boolean = naiveEquality _,
+    ignoreSchemaCheck: Boolean = false
   ): Unit = {
-    if (!actualDS.schema.equals(expectedDS.schema)) {
-      throw DatasetSchemaMismatch(
-        schemaMismatchMessage(
-          actualDS,
-          expectedDS
+    if (!ignoreSchemaCheck) {
+      if (!actualDS.schema.equals(expectedDS.schema)) {
+        throw DatasetSchemaMismatch(
+          schemaMismatchMessage(
+            actualDS,
+            expectedDS
+          )
         )
-      )
+      }
     }
     try {
       actualDS.rdd.cache

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -7,14 +7,24 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row}
 
 import scala.reflect.ClassTag
 
-case class DatasetSchemaMismatch(smth: String)  extends Exception(smth)
+case class DatasetSchemaMismatch(smth: String) extends Exception(smth)
+
 case class DatasetContentMismatch(smth: String) extends Exception(smth)
-case class DatasetCountMismatch(smth: String)   extends Exception(smth)
+
+case class DatasetCountMismatch(smth: String) extends Exception(smth)
 
 object DatasetComparerLike {
 
   def naiveEquality[T](o1: T, o2: T): Boolean = {
     o1.equals(o2)
+  }
+
+  def precisionEquality(o1: Row, o2: Row, precision: Double): Boolean = {
+    o1.equals(o2) || RowComparer.areRowsEqual(
+      o1,
+      o2,
+      precision
+    )
   }
 }
 
@@ -189,13 +199,11 @@ Expected DataFrame Row Count: '${expectedCount}'
     assertLargeDatasetEquality[Row](
       actualDF,
       expectedDF,
-      equals = (r1: Row, r2: Row) => {
-        r1.equals(r2) || RowComparer.areRowsEqual(
-          r1,
-          r2,
-          precision
-        )
-      }
+      DatasetComparerLike.precisionEquality(
+        _,
+        _,
+        precision
+      )
     )
   }
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
@@ -3,7 +3,6 @@ package com.github.mrpowers.spark.fast.tests
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
-
 import utest._
 
 object ColumnComparerTest extends TestSuite with ColumnComparer with SparkSessionTestWrapper {
@@ -70,7 +69,6 @@ object ColumnComparerTest extends TestSuite with ColumnComparer with SparkSessio
             "expected_name"
           )
         }
-
       }
 
       "doesn't thrown an error when the columns are equal" - {
@@ -420,7 +418,7 @@ object ColumnComparerTest extends TestSuite with ColumnComparer with SparkSessio
 
       }
 
-      "throws an error when two DoubleType columns are equal" - {
+      "throws an error when two DoubleType columns are not equal" - {
 
         val sourceData = Seq(
           Row(
@@ -451,11 +449,13 @@ object ColumnComparerTest extends TestSuite with ColumnComparer with SparkSessio
           StructType(sourceSchema)
         )
 
-        assertDoubleTypeColumnEquality(
-          df,
-          "d1",
-          "d2",
-          0.01
+        val e = intercept[ColumnMismatch](
+          assertDoubleTypeColumnEquality(
+            df,
+            "d1",
+            "d2",
+            0.01
+          )
         )
 
       }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -67,7 +67,6 @@ object DatasetComparerTest extends TestSuite with DatasetComparer with SparkSess
             expectedDS
           )
         }
-
       }
 
       "does nothing if the DataFrames have the same schemas and content" - {


### PR DESCRIPTION
@MrPowers to address #25 what can be done is reuse reuse all the logic we have in `DatasetComparer` as a POC I have converted  `assertColumnEquality`  to resue `assertLargeDatasetEquality`. This make for a clean codebase with optimal code reuse. I understand the ArrayPrettyPrint is the USP, but I believe we can achieve this in other ways.