### PR TITLE
on betterContentMismatchMessage print lines in one data set and not i…

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -38,7 +38,11 @@ Expected DataFrame Row Count: '${expectedCount}'
 
   private def betterContentMismatchMessage[T](a: Array[T], e: Array[T]): String = {
     "\n" + a
-      .zip(e)
+      .zipAll(
+        e,
+        "",
+        ""
+      )
       .map {
         case (r1, r2) =>
           if (r1.equals(r2)) {

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -451,6 +451,32 @@ object DatasetComparerTest extends TestSuite with DatasetComparer with SparkSess
         }
       }
 
+      "throws an error DataFrames have a different number of rows" - {
+        val sourceDF = spark.createDF(
+          List(
+            (1),
+            (5)
+          ),
+          List(("number", IntegerType, true))
+        )
+        val expectedDF = spark.createDF(
+          List(
+            (1),
+            (5),
+            (10)
+          ),
+          List(("number", IntegerType, true))
+        )
+
+        val e = intercept[DatasetContentMismatch] {
+          assertSmallDatasetEquality(
+            sourceDF,
+            expectedDF
+          )
+        }
+        assert(e.smth.count(_ == '\n') == 3)
+      }
+
     }
 
     'defaultSortDataset - {


### PR DESCRIPTION
…n the other

When one of the data frames contains the other the error message will show only the identical lines which makes the error hard to get. Instead the PR prints the lines that are in one of the data sets and not in the other.