### PR TITLE
added assertLargeDatasetEqualityWithoutOrder method; bumped the version to 0.20.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ spName := "MrPowers/spark-fast-tests"
 spShortDescription := "Fast tests with Spark"
 spDescription := "Test your code quickly"
 
-version := "0.20.0"
+version := "0.20.1"
 crossScalaVersions := Seq("2.11.12", "2.12.7")
 scalaVersion := "2.11.12"
 sparkVersion := "2.4.3"

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -273,8 +273,7 @@ ${DataFramePrettyPrint.showString(
         // Group them together and filter for difference
         val maxUnequalRowsToShow = 10
         val unequalRDD = ds1Keyed.cogroup(ds2Keyed).filter {
-          case (_, (i1, i2)) =>
-            i1.isEmpty || i2.isEmpty || i1 != i2
+          case (_, (i1, i2)) => i1.isEmpty || i2.isEmpty || i1 != i2
         }
 
         if (!unequalRDD.isEmpty()) {
@@ -286,10 +285,8 @@ ${DataFramePrettyPrint.showString(
           )
         }
         unequalRDD.take(maxUnequalRowsToShow).headOption.map {
-          case (v, (i1, i2)) =>
-            (v, i1.headOption.getOrElse(0), i2.headOption.getOrElse(0))
+          case (v, (i1, i2)) => (v, i1.headOption.getOrElse(0), i2.headOption.getOrElse(0))
         }
-
       } finally {
         ds1.rdd.unpersist()
         ds2.rdd.unpersist()

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -274,7 +274,7 @@ ${DataFramePrettyPrint.showString(
         val maxUnequalRowsToShow = 10
         val unequalRDD = ds1Keyed.cogroup(ds2Keyed).filter {
           case (_, (i1, i2)) =>
-            i1.isEmpty || i2.isEmpty || i1.head != i2.head
+            i1.isEmpty || i2.isEmpty || i1 != i2
         }
 
         if (!unequalRDD.isEmpty()) {

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -398,6 +398,10 @@ object DatasetComparerTest extends TestSuite with DatasetComparer with SparkSess
           expectedDF,
           orderedComparison = false
         )
+        assertLargeDatasetEqualityWithoutOrder(
+          sourceDF,
+          expectedDF
+        )
         assertSmallDatasetEquality(
           sourceDF,
           expectedDF,
@@ -420,6 +424,7 @@ object DatasetComparerTest extends TestSuite with DatasetComparer with SparkSess
         )
 
         assertLargeDatasetEquality(sourceDS, expectedDS, orderedComparison = false)
+        assertLargeDatasetEqualityWithoutOrder(sourceDS, expectedDS)
         assertSmallDatasetEquality(sourceDS, expectedDS, orderedComparison = false)
       }
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -140,6 +140,9 @@ object DatasetComparerTest extends TestSuite with DatasetComparer with SparkSess
           assertLargeDatasetEquality(sourceDF, expectedDF)
         }
         val e2 = intercept[DatasetSchemaMismatch] {
+          assertLargeDatasetEqualityWithoutOrder(sourceDF, expectedDF)
+        }
+        val e3 = intercept[DatasetSchemaMismatch] {
           assertSmallDatasetEquality(sourceDF, expectedDF)
         }
       }


### PR DESCRIPTION
Github issue: https://github.com/MrPowers/spark-fast-tests/issues/58

Change log
 - added `schemaComparer()`
- added `assertLargeDatasetEqualityWithoutOrder()`


Borrowed the code from `https://github.com/holdenk/spark-testing-base/blob/master/core/src/main/1.3/scala/com/holdenkarau/spark/testing/RDDComparisons.scala#L115`. Credit goes to @limansky