### PR TITLE
Add Github Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        scala: ["2.12.12", "2.11.12"]
+        spark: ["2.4.0", "3.0.0"]
+        exclude:
+          - scala: "2.11.12"
+            spark: "3.0.0"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: olafurpg/setup-scala@v5
+      - name: Test
+        run: sbt -Dspark.testVersion=${{ matrix.spark  }} ++${{ matrix.scala }} test
+      - name: Assembly
+        run: sbt ++${{ matrix.scala }} "set test in assembly := {}" assembly


### PR DESCRIPTION
As a first step towards https://github.com/MrPowers/spark-fast-tests/issues/24 I thought it would be a good idea to have an automated Github build (which is much faster than Travis).
If you like it, you can remove Travis and I'll create a follow-up PR for automated publishing.