### PR TITLE
fix: show missing content in case datasets don't match

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -59,7 +59,7 @@ Expected DataFrame Row Count: '${expectedCount}'
 
   private def betterContentMismatchMessage[T](a: Array[T], e: Array[T]): String = {
     // Diffs\n is a hack, but a newline isn't added in ScalaTest unless we add "Diffs"
-    "Diffs\n" ++ ArrayPrettyPrint.showTwoColumnString(Array(("Actual Content", "Expected Content")) ++ a.zip(e))
+    "Diffs\n" ++ ArrayPrettyPrint.showTwoColumnString(Array(("Actual Content", "Expected Content")) ++ a.zipAll(e, "": Any, "": Any))
   }
 
   private def unequalRDDMessage[T](unequalRDD: RDD[(Long, (T, T))], length: Int): String = {

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -39,7 +39,80 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
         expectedDF
       )
     }
+    assert(e.getMessage.indexOf("bob") >= 0)
+    assert(e.getMessage.indexOf("camila") >= 0)
+  }
 
+  "also print a descriptive error message if the right side is missing" in {
+    val sourceDF = spark.createDF(
+      List(
+        ("bob", 1, "uk"),
+        ("camila", 5, "peru"),
+        ("jean-jacques", 4, "france")
+      ),
+      List(
+        ("name", StringType, true),
+        ("age", IntegerType, true),
+        ("country", StringType, true)
+      )
+    )
+
+    val expectedDF = spark.createDF(
+      List(
+        ("bob", 1, "france"),
+        ("camila", 5, "peru")
+      ),
+      List(
+        ("name", StringType, true),
+        ("age", IntegerType, true),
+        ("country", StringType, true)
+      )
+    )
+
+    val e = intercept[DatasetContentMismatch] {
+      assertSmallDataFrameEquality(
+        sourceDF,
+        expectedDF
+      )
+    }
+
+    assert(e.getMessage.indexOf("jean-jacques") >= 0)
+  }
+
+  "also print a descriptive error message if the left side is missing" in {
+    val sourceDF = spark.createDF(
+      List(
+        ("bob", 1, "uk"),
+        ("camila", 5, "peru")
+      ),
+      List(
+        ("name", StringType, true),
+        ("age", IntegerType, true),
+        ("country", StringType, true)
+      )
+    )
+
+    val expectedDF = spark.createDF(
+      List(
+        ("bob", 1, "france"),
+        ("camila", 5, "peru"),
+        ("jean-claude", 4, "france")
+      ),
+      List(
+        ("name", StringType, true),
+        ("age", IntegerType, true),
+        ("country", StringType, true)
+      )
+    )
+
+    val e = intercept[DatasetContentMismatch] {
+      assertSmallDataFrameEquality(
+        sourceDF,
+        expectedDF
+      )
+    }
+
+    assert(e.getMessage.indexOf("jean-claude") >= 0)
   }
 
   "checkingDataFrameEquality" - {


### PR DESCRIPTION
contrary to the method showing schema mismatches, `betterContentMismatchMessages` can show 'there are diffs' but not show the actual difference in case the difference is data missing from either side.

This patch adds tests, and switches one ".zip" to a ".zipAll" to fix this.