### PR TITLE
Updated to scala 2.13 compatibility (to support spark 3.2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,17 +6,17 @@ organization := "com.github.mrpowers"
 name := "spark-fast-tests"
 
 version := "1.0.0"
-crossScalaVersions := Seq("2.12.12")
+crossScalaVersions := Seq("2.13.5", "2.12.12")
 scalaVersion := crossScalaVersions.value.head
 val sparkVersion = "3.0.1"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % "test"
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 
 fork in Test := true
-javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled","-Duser.timezone=GMT")
+javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled", "-Duser.timezone=GMT")
 
 licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 homepage := Some(url("https://github.com/MrPowers/spark-fast-tests"))

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/ArrayUtil.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/ArrayUtil.scala
@@ -5,7 +5,7 @@ import com.github.mrpowers.spark.fast.tests.ufansi.EscapeAttr
 import java.time.format.DateTimeFormatter
 import org.apache.commons.lang3.StringUtils
 
-object ArrayPrettyPrint {
+object ArrayUtil {
 
   def weirdTypesToStrings(arr: Array[(Any, Any)], truncate: Int = 20): Array[List[String]] = {
     arr.map { row =>
@@ -160,4 +160,21 @@ object ArrayPrettyPrint {
     sb.toString()
   }
 
+  // The following code is taken from: https://github.com/scala/scala/blob/86e75db7f36bcafdd75302f2c2cca0c68413214d/src/partest/scala/tools/partest/Util.scala
+  def prettyArray(a: Array[_]): collection.IndexedSeq[Any] = new collection.AbstractSeq[Any] with collection.IndexedSeq[Any] {
+    def length: Int = a.length
+
+    def apply(idx: Int): Any = a(idx) match {
+      case x: AnyRef if x.getClass.isArray => prettyArray(x.asInstanceOf[Array[_]])
+      case x                               => x
+    }
+
+    // Ignore deprecation warning in 2.13 - this is the correct def for 2.12 compatibility
+    override def stringPrefix: String = "Array"
+  }
+
+  // The following code is taken from: https://github.com/scala/scala/blob/86e75db7f36bcafdd75302f2c2cca0c68413214d/src/partest/scala/tools/partest/Util.scala
+  implicit class ArrayDeep(val a: Array[_]) extends AnyVal {
+    def deep: collection.IndexedSeq[Any] = prettyArray(a)
+  }
 }

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/ColumnComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/ColumnComparer.scala
@@ -17,7 +17,7 @@ trait ColumnComparer {
     val colName2Elements = elements.map(_(1))
     if (!colName1Elements.sameElements(colName2Elements)) {
       // Diffs\n is a hack, but a newline isn't added in ScalaTest unless we add "Diffs"
-      val mismatchMessage = "Diffs\n" + ArrayPrettyPrint.showTwoColumnString(
+      val mismatchMessage = "Diffs\n" + ArrayUtil.showTwoColumnString(
         Array((colName1, colName2)) ++ colName1Elements.zip(colName2Elements)
       )
       throw ColumnMismatch(mismatchMessage)
@@ -32,6 +32,8 @@ trait ColumnComparer {
   // possibly rename this to assertDeepColumnEquality...
   // would deep equality comparison help when comparing other types of columns?
   def assertBinaryTypeColumnEquality(df: DataFrame, colName1: String, colName2: String): Unit = {
+    import ArrayUtil._
+
     val elements = df
       .select(colName1, colName2)
       .collect()
@@ -39,7 +41,7 @@ trait ColumnComparer {
     val colName2Elements = elements.map(_(1))
     if (!colName1Elements.deep.sameElements(colName2Elements.deep)) {
       // Diffs\n is a hack, but a newline isn't added in ScalaTest unless we add "Diffs"
-      val mismatchMessage = "Diffs\n" + ArrayPrettyPrint.showTwoColumnString(
+      val mismatchMessage = "Diffs\n" + ArrayUtil.showTwoColumnString(
         Array((colName1, colName2)) ++ colName1Elements.zip(colName2Elements)
       )
       throw ColumnMismatch(mismatchMessage)
@@ -85,7 +87,7 @@ trait ColumnComparer {
       val colName1Elements = elements.map(_(0))
       val colName2Elements = elements.map(_(1))
       // Diffs\n is a hack, but a newline isn't added in ScalaTest unless we add "Diffs"
-      val mismatchMessage = "Diffs\n" + ArrayPrettyPrint.showTwoColumnStringColorCustomizable(
+      val mismatchMessage = "Diffs\n" + ArrayUtil.showTwoColumnStringColorCustomizable(
         Array((colName1, colName2)) ++ colName1Elements.zip(colName2Elements),
         rowsEqual.toArray
       )
@@ -132,7 +134,7 @@ trait ColumnComparer {
       val colName1Elements = elements.map(_(0))
       val colName2Elements = elements.map(_(1))
       // Diffs\n is a hack, but a newline isn't added in ScalaTest unless we add "Diffs"
-      val mismatchMessage = "Diffs\n" + ArrayPrettyPrint.showTwoColumnStringColorCustomizable(
+      val mismatchMessage = "Diffs\n" + ArrayUtil.showTwoColumnStringColorCustomizable(
         Array((colName1, colName2)) ++ colName1Elements.zip(colName2Elements),
         rowsEqual.toArray
       )
@@ -167,7 +169,7 @@ trait ColumnComparer {
       val colName1Elements = elements.map(_(0))
       val colName2Elements = elements.map(_(1))
       // Diffs\n is a hack, but a newline isn't added in ScalaTest unless we add "Diffs"
-      val mismatchMessage = "Diffs\n" + ArrayPrettyPrint.showTwoColumnString(
+      val mismatchMessage = "Diffs\n" + ArrayUtil.showTwoColumnString(
         Array((colName1, colName2)) ++ colName1Elements.zip(colName2Elements)
       )
       throw ColumnMismatch(mismatchMessage)

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -60,7 +60,7 @@ Expected DataFrame Row Count: '${expectedCount}'
   private def betterContentMismatchMessage[T](a: Array[T], e: Array[T], truncate: Int): String = {
     // Diffs\n is a hack, but a newline isn't added in ScalaTest unless we add "Diffs"
     val arr = Array(("Actual Content", "Expected Content")) ++ a.zipAll(e, "": Any, "": Any)
-    "Diffs\n" ++ ArrayPrettyPrint.showTwoColumnString(arr, truncate)
+    "Diffs\n" ++ ArrayUtil.showTwoColumnString(arr, truncate)
   }
 
   private def unequalRDDMessage[T](unequalRDD: RDD[(Long, (T, T))], length: Int): String = {

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/ufansi/Fansi.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/ufansi/Fansi.scala
@@ -7,6 +7,7 @@ import java.util
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.language.postfixOps
 
 object sourcecode {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
@@ -4,30 +4,30 @@ import java.sql.Date
 import java.time.LocalDate
 import org.scalatest.FreeSpec
 
-class ArrayPrettyPrintTest extends FreeSpec {
+class ArrayUtilTest extends FreeSpec {
 
   "blah" in {
     val arr: Array[(Any, Any)] = Array(("hi", "there"), ("fun", "train"))
-    val res                    = ArrayPrettyPrint.weirdTypesToStrings(arr, 10)
+    val res                    = ArrayUtil.weirdTypesToStrings(arr, 10)
     assert(res sameElements Array(List("hi", "there"), List("fun", "train")))
   }
 
   "showTwoColumnString" in {
     val arr: Array[(Any, Any)] = Array(("word1", "word2"), ("hi", "there"), ("fun", "train"))
-    println(ArrayPrettyPrint.showTwoColumnString(arr, 10))
+    println(ArrayUtil.showTwoColumnString(arr, 10))
   }
 
   "showTwoColumnDate" in {
     val now = LocalDate.now()
     val arr: Array[(Any, Any)] =
       Array(("word1", "word2"), (Date.valueOf(now), Date.valueOf(now)), (Date.valueOf(now.plusDays(-1)), Date.valueOf(now)))
-    println(ArrayPrettyPrint.showTwoColumnString(arr, 10))
+    println(ArrayUtil.showTwoColumnString(arr, 10))
   }
 
   "dumbshowTwoColumnString" in {
     val arr: Array[(Any, Any)] = Array(("word1", "word2"), ("hi", "there"), ("fun", "train"))
     val rowEqual               = Array(true, false)
-    println(ArrayPrettyPrint.showTwoColumnStringColorCustomizable(arr, rowEqual))
+    println(ArrayUtil.showTwoColumnStringColorCustomizable(arr, rowEqual))
   }
 
 }


### PR DESCRIPTION
Made compatible with scala 2.13 with cross compilation:
- Added `ArrayUtil.deep` (copied from scala test utils) since `Array.deep` has been removed in scala 2.13
- Merged `ArrayPrettyPrint` into `ArrayUtil`