### PR TITLE
ignoreNullable on complex Spark data types

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -1,6 +1,6 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
 
 object SchemaComparer {
 
@@ -12,8 +12,18 @@ object SchemaComparer {
       structFields.forall { t =>
         ((t._1.nullable == t._2.nullable) || ignoreNullable) &&
         ((t._1.name == t._2.name) || ignoreColumnNames) &&
-        (t._1.dataType == t._2.dataType)
+        equals(t._1.dataType, t._2.dataType, ignoreNullable, ignoreColumnNames)
       }
+    }
+  }
+
+  def equals(dt1: DataType, dt2: DataType, ignoreNullable: Boolean, ignoreColumnNames: Boolean): Boolean = {
+    (ignoreNullable, dt1, dt2) match {
+      case (true, st1: StructType, st2: StructType) => equals(st1, st2, ignoreNullable, ignoreColumnNames)
+      case (true, ArrayType(vdt1, _), ArrayType(vdt2, _)) => equals(vdt1, vdt2, ignoreNullable, ignoreColumnNames)
+      case (true, MapType(kdt1, vdt1, _), MapType(kdt2, vdt2, _)) =>
+        equals(kdt1, kdt2, ignoreNullable, ignoreColumnNames) && equals(vdt1, vdt2, ignoreNullable, ignoreColumnNames)
+      case _ => dt1 == dt2
     }
   }
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -68,6 +68,37 @@ class SchemaComparerTest extends FreeSpec {
       assert(SchemaComparer.equals(s1, s2, ignoreNullable = true))
     }
 
+
+    "can ignore the nullable flag when determining equality on complex data types" in {
+      val s1 = StructType(
+        Seq(
+          StructField("something", StringType, true),
+          StructField("array", ArrayType(StringType, containsNull = true), true),
+          StructField("map", MapType(StringType, StringType, valueContainsNull = false), true),
+          StructField("struct", StructType(StructType(
+            Seq(
+              StructField("something", StringType, false),
+              StructField("mood", ArrayType(StringType, containsNull = false), true)
+            )
+          )), true)
+        )
+      )
+      val s2 = StructType(
+        Seq(
+          StructField("something", StringType, false),
+          StructField("array", ArrayType(StringType, containsNull = false), true),
+          StructField("map", MapType(StringType, StringType, valueContainsNull = true), true),
+          StructField("struct", StructType(StructType(
+            Seq(
+              StructField("something", StringType, false),
+              StructField("mood", ArrayType(StringType, containsNull = true), true)
+            )
+          )), false)
+        )
+      )
+      assert(SchemaComparer.equals(s1, s2, ignoreNullable = true))
+    }
+
     "can ignore the column names flag when determining equality" in {
       val s1 = StructType(
         Seq(


### PR DESCRIPTION
This is a problem we have had for quite a while, it didn't seem that hard to fix. Let me know if it makes the comparison too complex. I believe it will fix #96. 