### PR TITLE
Enable scala 2.13 support with spark 3.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: ["2.12.12"]
-        spark: ["3.0.1"]
+        scala: ["2.13.7", "2.12.12"]
+        spark: ["3.2.0", "3.0.1"]
+        exclude:
+          - scala: 2.13.7
+            spark: 3.0.1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ organization := "com.github.mrpowers"
 name := "spark-fast-tests"
 
 version := "1.0.0"
-crossScalaVersions := Seq("2.12.12")
+crossScalaVersions := Seq("2.13.7", "2.12.12")
 scalaVersion := crossScalaVersions.value.head
-val sparkVersion = "3.0.1"
+val sparkVersion = "3.2.0"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % "test"

--- a/scripts/multi_spark_releases.sh
+++ b/scripts/multi_spark_releases.sh
@@ -10,7 +10,7 @@ if [ "$SPARK_DARIA_GITHUB_RELEASE" = "" ]
     exit 1
 fi
 
-for sparkVersion in 2.2.0 2.2.1 2.3.0; do
+for sparkVersion in 2.2.0 2.2.1 2.3.0 3.0.1 3.2.0; do
   echo $sparkVersion
   sed -i '' "s/^val sparkVersion.*/val sparkVersion = \"$sparkVersion\"/" build.sbt
   $SPARK_DARIA_GITHUB_RELEASE package


### PR DESCRIPTION
Hi, @MrPowers

Since spark 3.2 (with scala 2.13 support) has been released, it would be great to use this `spark-fast-tests` library with the latest spark version. 
In this MR, I changed the versions, however, I didn't fully get how you handle multiple scala versions when releasing in `scripts/multi_spark_releases.sh` (e.g. when a new feature is added - do you release a package for spark 2.2.0 with scala 2.11?).
If you have no interest in maintaining this, @vitalvi and myself can take care of this repo (since we use it at our company).

Related to issue: https://github.com/MrPowers/spark-fast-tests/issues/102