### PR TITLE
Enable cross spark version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: ["2.12.12"]
-        spark: ["3.0.1"]
+        spark: ["2.4.8","3.0.3","3.1.3","3.2.1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v10
       - name: Test
-        run: sbt -Dspark.testVersion=${{ matrix.spark  }} ++${{ matrix.scala }} test
+        run: sbt -Dspark.testVersion=${{ matrix.spark  }} +test

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,57 @@ project/boot/
 *.iml
 
 *.swp
+
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+**/.bloop
+.bsp/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+.idea
+
+# ENSIME specific
+.ensime_cache/
+.ensime
+
+.metals/
+.ammonite/
+metals.sbt
+metals/project/
+
+.vscode/
+
+local.*
+
+.DS_Store
+
+node_modules
+
+lib/core/metadata.js
+lib/core/MetadataBlog.js
+
+website/translated_docs
+website/build/
+website/yarn.lock
+website/node_modules
+website/i18n/*
+!website/i18n/en.json
+website/.docusaurus
+website/.cache-loader
+
+project/metals.sbt
+coursier

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,26 @@ organization := "com.github.mrpowers"
 name := "spark-fast-tests"
 
 version := "1.2.0"
-crossScalaVersions := Seq("2.12.15", "2.13.8")
-scalaVersion := crossScalaVersions.value.head
-val sparkVersion = "3.2.1"
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
+val versionRegex      = """^(.*)\.(.*)\.(.*)$""".r
+
+val sparkVersion = settingKey[String]("Spark version")
+
+val scala2_13= "2.13.8"
+val scala2_12= "2.12.15"
+val scala2_11= "2.11.12"
+
+sparkVersion := System.getProperty("spark.testVersion", "3.2.1")
+crossScalaVersions := {sparkVersion.value match {
+  case versionRegex("3", m, _) if m.toInt >= 2 => Seq(scala2_12, scala2_13)
+  case versionRegex("3", _ , _) => Seq(scala2_12)
+  case versionRegex("2", _ , _)  => Seq(scala2_11)
+}
+}
+
+scalaVersion := crossScalaVersions.value.head
+
+libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % "test"
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.3
+sbt.version=1.6.2


### PR DESCRIPTION
This pull request allows choosing the spark version when running sbt. It contains the logic to select the valid versions of scala depending on the version of spark. By default, it runs with the latest spark version at the moment (3.1.2)

I've tested that spark-fast-test passes all the test against spark 2.4 version. It will be great to have published a scala 2.11 version published to make the people that still suffer this version some help.

To select the version, add the following option: (as expected in the CI)
`sbt -Dspark.testVersion=2.4.4 test`


To publish it only requires executing against spark versions 2.4.8 and 3.2.1 at this moment.