### PR TITLE
Feature: Timestamps tolerance for assertApproximateDataFrameEquality

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
 
 import scala.reflect.ClassTag
+import java.time.Duration
 
 case class DatasetSchemaMismatch(smth: String)  extends Exception(smth)
 case class DatasetContentMismatch(smth: String) extends Exception(smth)
@@ -175,11 +176,12 @@ Expected DataFrame Row Count: '${expectedCount}'
   def assertApproximateDataFrameEquality(actualDF: DataFrame,
                                          expectedDF: DataFrame,
                                          precision: Double,
+                                         precisionTimestamps: Duration = Duration.ZERO,
                                          ignoreNullable: Boolean = false,
                                          ignoreColumnNames: Boolean = false,
                                          orderedComparison: Boolean = true): Unit = {
     val e = (r1: Row, r2: Row) => {
-      r1.equals(r2) || RowComparer.areRowsEqual(r1, r2, precision)
+      r1.equals(r2) || RowComparer.areRowsEqual(r1, r2, precision, precisionTimestamps)
     }
     assertLargeDatasetEquality[Row](
       actualDF,

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/RowComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/RowComparer.scala
@@ -1,14 +1,15 @@
 package com.github.mrpowers.spark.fast.tests
 
 import org.apache.spark.sql.Row
-
 import java.sql.Timestamp
 import scala.math.abs
+
+import java.time.Duration
 
 object RowComparer {
 
   /** Approximate equality, based on equals from [[Row]] */
-  def areRowsEqual(r1: Row, r2: Row, tol: Double): Boolean = {
+  def areRowsEqual(r1: Row, r2: Row, tol: Double, tolTimestamp: Duration): Boolean = {
     if (r1.length != r2.length) {
       return false
     } else {
@@ -53,7 +54,9 @@ object RowComparer {
               }
 
             case t1: Timestamp =>
-              if (abs(t1.getTime - o2.asInstanceOf[Timestamp].getTime) > tol) {
+              val t1Instant = t1.toInstant
+              val t2Instant = o2.asInstanceOf[Timestamp].toInstant
+              if (Duration.between(t1Instant, t2Instant).abs.compareTo(tolTimestamp) > 0) {
                 return false
               }
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
@@ -2,9 +2,9 @@ package com.github.mrpowers.spark.fast.tests
 
 import java.sql.Date
 import java.time.LocalDate
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class ArrayUtilTest extends FreeSpec {
+class ArrayUtilTest extends AnyFreeSpec {
 
   "blah" in {
     val arr: Array[(Any, Any)] = Array(("hi", "there"), ("fun", "train"))

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
@@ -6,9 +6,9 @@ import org.apache.spark.sql.types._
 import java.sql.Date
 import java.sql.Timestamp
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class ColumnComparerTest extends FreeSpec with ColumnComparer with SparkSessionTestWrapper {
+class ColumnComparerTest extends AnyFreeSpec with ColumnComparer with SparkSessionTestWrapper {
 
   "assertColumnEquality" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -3,9 +3,9 @@ package com.github.mrpowers.spark.fast.tests
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import SparkSessionExt._
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSessionTestWrapper {
+class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with SparkSessionTestWrapper {
 
   "prints a descriptive error message if it bugs out" in {
     val sourceDF = spark.createDF(

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -1,7 +1,9 @@
 package com.github.mrpowers.spark.fast.tests
 
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 import SparkSessionExt._
+import java.time.Duration
 
 import org.scalatest.FreeSpec
 
@@ -636,6 +638,23 @@ class DatasetComparerTest extends FreeSpec with DatasetComparer with SparkSessio
       ).toDF("col_B", "col_C", "col_A", "col_D")
 
       assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+    }
+
+    "can work with timestamps precision" in {
+      import spark.implicits._
+      val ds1 = Seq(
+        ("1", "2019-10-01 00:00:00", 26.762499999999996, "A"),
+        ("1", "2019-10-01 00:00:00", 26.762499999999996, "B")
+      ).toDF("col_B", "col_C", "col_A", "col_D")
+        .withColumn("col_C", col("col_C").cast(TimestampType))
+
+      val ds2 = Seq(
+        ("1", "2019-10-01 00:00:01", 26.762499999999946, "A"),
+        ("1", "2019-10-01 00:00:01", 26.76249999999991, "B")
+      ).toDF("col_B", "col_C", "col_A", "col_D")
+        .withColumn("col_C", col("col_C").cast(TimestampType))
+
+      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, Duration.ofSeconds(1), orderedComparison = false)
     }
 
   }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.types._
 import SparkSessionExt._
 import java.time.Duration
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 object Person {
 
@@ -16,7 +16,7 @@ object Person {
 case class Person(name: String, age: Int)
 case class PrecisePerson(name: String, age: Double)
 
-class DatasetComparerTest extends FreeSpec with DatasetComparer with SparkSessionTestWrapper {
+class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSessionTestWrapper {
 
   "checkDatasetEquality" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ExamplesTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ExamplesTest.scala
@@ -3,9 +3,9 @@
 //import org.apache.spark.sql.types._
 //import SparkSessionExt._
 //
-//import org.scalatest.FreeSpec
+//import org.scalatest.freespec.AnyFreeSpec
 //
-//class ExamplesTest extends FreeSpec with SparkSessionTestWrapper with DataFrameComparer with ColumnComparer {
+//class ExamplesTest extends AnyFreeSpec with SparkSessionTestWrapper with DataFrameComparer with ColumnComparer {
 //
 //  "assertSmallDatasetEquality" - {
 //

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/RDDComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/RDDComparerTest.scala
@@ -1,8 +1,8 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class RDDComparerTest extends FreeSpec with RDDComparer with SparkSessionTestWrapper {
+class RDDComparerTest extends AnyFreeSpec with RDDComparer with SparkSessionTestWrapper {
 
   "contentMismatchMessage" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/RowComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/RowComparerTest.scala
@@ -1,10 +1,10 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 import org.apache.spark.sql.Row
 
-class RowComparerTest extends FreeSpec {
+class RowComparerTest extends AnyFreeSpec {
 
   "areRowsEqual" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -1,9 +1,9 @@
 package com.github.mrpowers.spark.fast.tests
 
 import org.apache.spark.sql.types._
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class SchemaComparerTest extends FreeSpec {
+class SchemaComparerTest extends AnyFreeSpec {
 
   "equals" - {
 


### PR DESCRIPTION
Before this PR `assertApproximateDataFrameEquality` method shared `precision` argument to check decimal numbers (`decimal` type --> `0 < value < 1`) & timestamps (`long` type --> `0 < value`)