### PR TITLE
Non RDD assertLargeDatasetEquality

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,12 @@ To compare large DataFrames that are partitioned across different nodes in a clu
 `assertLargeDatasetEquality` method.
 
 ```scala
-assertLargeDatasetEquality(actualDF, expectedDF)
+assertLargeDatasetEquality(actualDF, expectedDF, primaryKeys = Seq("id"))
 ```
 
 `assertSmallDatasetEquality` is faster for test suites that run on your local machine.  `assertLargeDatasetEquality`
-should only be used for DataFrames that are split across nodes in a cluster.
+should only be used for DataFrames that are split across nodes in a cluster. Large comparisons require non-empty
+`primaryKeys` so rows can be matched reliably across partitions.
 
 #### Unordered DataFrame equality comparisons
 
@@ -334,7 +335,7 @@ val expectedDF = spark.createDF(
   )
 )
 
-assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
 ```
 
 ### Column Equality

--- a/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerBenchmark.scala
+++ b/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerBenchmark.scala
@@ -7,6 +7,7 @@ import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 import scala.util.Try
 
+@State(Scope.Benchmark)
 private class ColumnComparerBenchmark extends ColumnComparer {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))

--- a/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerBenchmark.scala
+++ b/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerBenchmark.scala
@@ -24,14 +24,20 @@ private class DataFrameComparerBenchmark extends DataFrameComparer {
     spark.sparkContext.setLogLevel("ERROR")
 
     import spark.implicits._
-    val sameData = Seq.fill(50)("1", "10/01/2019", 26.762499999999996)
-    val ds1Data  = sameData ++ Seq.fill(50)("1", "11/01/2019", 26.76249999999991)
-    val ds2Data  = sameData ++ Seq.fill(50)("3", "12/01/2019", 26.76249999999991)
+    val sameData = Seq.tabulate(100) { i =>
+      val day = if (i < 50) "10/01/2019" else "11/01/2019"
+      (i.toLong, "1", day, 26.762499999999996)
+    }
+    val ds1Data = sameData
+    val ds2Data = sameData.map {
+      case (id, colB, colC, value) if id >= 50 => (id, colB, colC, value + 2)
+      case row                                 => row
+    }
 
-    val ds1 = ds1Data.toDF("col_B", "col_C", "col_A")
-    val ds2 = ds2Data.toDF("col_B", "col_C", "col_A")
+    val ds1 = ds1Data.toDF("id", "col_B", "col_C", "col_A")
+    val ds2 = ds2Data.toDF("id", "col_B", "col_C", "col_A")
 
-    val result = Try(assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false))
+    val result = Try(assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, primaryKeys = Seq("id")))
 
     blackHole.consume(result)
     result.isSuccess

--- a/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerBenchmark.scala
+++ b/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerBenchmark.scala
@@ -7,6 +7,7 @@ import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 import scala.util.Try
 
+@State(Scope.Benchmark)
 private class DataFrameComparerBenchmark extends DataFrameComparer {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))

--- a/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerBenchmark.scala
+++ b/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerBenchmark.scala
@@ -1,0 +1,72 @@
+package com.github.mrpowers.spark.fast.tests
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.col
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.util.Try
+
+private class DatasetComparerBenchmark {
+  private val datasetComparer = new DatasetComparer {}
+
+  def getSparkSession: SparkSession = {
+    val session = SparkSession
+      .builder()
+      .master("local")
+      .appName("spark session")
+      .getOrCreate()
+    session.sparkContext.setLogLevel("ERROR")
+    session
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @Fork(value = 2)
+  @Warmup(iterations = 10)
+  @Measurement(iterations = 10)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def assertLargeDatasetEqualityWithSinglePrimaryKey(blackHole: Blackhole): Boolean = {
+    val spark = getSparkSession
+    val ds1   = spark.range(0, 1000000, 1, 8)
+    val ds3   = ds1
+
+    val result = Try(datasetComparer.assertLargeDatasetEquality(ds1, ds3, primaryKeys = Seq("id")))
+
+    blackHole.consume(result)
+    result.isSuccess
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @Fork(value = 2)
+  @Warmup(iterations = 10)
+  @Measurement(iterations = 10)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def assertLargeDatasetEqualityWithCompositePrimaryKey2(blackHole: Blackhole): Boolean = {
+    val spark  = getSparkSession
+    val ds1    = spark.range(0, 1000000, 1, 8).withColumn("id2", col("id") + 1)
+    val ds3    = ds1
+    val result = Try(datasetComparer.assertLargeDatasetEquality(ds1, ds3, primaryKeys = Seq("id", "id2")))
+
+    blackHole.consume(result)
+    result.isSuccess
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @Fork(value = 2)
+  @Warmup(iterations = 10)
+  @Measurement(iterations = 10)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  def assertLargeDatasetEqualityWithCompositePrimaryKey3(blackHole: Blackhole): Boolean = {
+    val spark  = getSparkSession
+    val ds1    = spark.range(0, 1000000, 1, 8).withColumn("id2", col("id") + 1).withColumn("id3", col("id2") + 1)
+    val ds3    = ds1
+    val result = Try(datasetComparer.assertLargeDatasetEquality(ds1, ds3, primaryKeys = Seq("id", "id2", "id3")))
+
+    blackHole.consume(result)
+    result.isSuccess
+  }
+}

--- a/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerBenchmark.scala
+++ b/benchmarks/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerBenchmark.scala
@@ -8,6 +8,7 @@ import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 import scala.util.Try
 
+@State(Scope.Benchmark)
 private class DatasetComparerBenchmark {
   private val datasetComparer = new DatasetComparer {}
 

--- a/spark/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
+++ b/spark/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
@@ -1,9 +1,9 @@
 package com.github.mrpowers.spark.fast.tests
 
-import com.github.mrpowers.spark.fast.tests.api._
-import org.apache.spark.sql.{DataFrame, Row}
 import com.github.mrpowers.spark.fast.tests.DataframeDiffOutputFormat.DataframeDiffOutputFormat
+import com.github.mrpowers.spark.fast.tests.api._
 import SparkDataFrameLike.instance
+import org.apache.spark.sql.{DataFrame, Row}
 
 /**
  * Provides assertion utilities for Spark DataFrames.
@@ -47,7 +47,8 @@ trait DataFrameComparer extends DatasetComparer {
       ignoreColumnNames: Boolean = false,
       orderedComparison: Boolean = true,
       ignoreColumnOrder: Boolean = false,
-      ignoreMetadata: Boolean = true
+      ignoreMetadata: Boolean = true,
+      primaryKeys: Seq[String]
   ): Unit = {
     assertLargeDatasetEquality(
       actualDF,
@@ -56,7 +57,8 @@ trait DataFrameComparer extends DatasetComparer {
       ignoreColumnNames = ignoreColumnNames,
       orderedComparison = orderedComparison,
       ignoreColumnOrder = ignoreColumnOrder,
-      ignoreMetadata = ignoreMetadata
+      ignoreMetadata = ignoreMetadata,
+      primaryKeys = primaryKeys
     )
   }
 
@@ -100,7 +102,8 @@ trait DataFrameComparer extends DatasetComparer {
       ignoreColumnNames: Boolean = false,
       orderedComparison: Boolean = true,
       ignoreColumnOrder: Boolean = false,
-      ignoreMetadata: Boolean = true
+      ignoreMetadata: Boolean = true,
+      primaryKeys: Seq[String]
   ): Unit = {
     assertLargeDatasetEquality(
       actualDF,
@@ -110,7 +113,8 @@ trait DataFrameComparer extends DatasetComparer {
       ignoreColumnNames,
       orderedComparison,
       ignoreColumnOrder,
-      ignoreMetadata
+      ignoreMetadata,
+      primaryKeys
     )
   }
 }

--- a/spark/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/spark/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -1,11 +1,10 @@
 package com.github.mrpowers.spark.fast.tests
 
 import com.github.mrpowers.spark.fast.tests.DataframeDiffOutputFormat.DataframeDiffOutputFormat
-import com.github.mrpowers.spark.fast.tests.DatasetComparer.maxUnequalRowsToShow
+import com.github.mrpowers.spark.fast.tests.DatasetUtils.DatasetOps
 import com.github.mrpowers.spark.fast.tests.api._
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{DataFrame, Dataset, Encoder, Row}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 
 import scala.reflect.ClassTag
 
@@ -14,6 +13,10 @@ import scala.reflect.ClassTag
  */
 trait DatasetComparer extends DataFrameLikeComparer {
 
+  private val primaryKeysRequiredMessage =
+    "assertLargeDatasetEquality requires non-empty primaryKeys. Provide stable unique key columns for each row."
+  private val defaultEqualityExpr = col("actual") <=> col("expected")
+
   private def countMismatchMessage(actualCount: Long, expectedCount: Long): String = {
     s"""
 Actual DataFrame Row Count: '$actualCount'
@@ -21,13 +24,12 @@ Expected DataFrame Row Count: '$expectedCount'
 """
   }
 
-  private def unequalRDDMessage[T](unequalRDD: RDD[(Long, (T, T))], length: Int): String = {
-    "\nRow Index | Actual Row | Expected Row\n" + unequalRDD
-      .take(length)
-      .map { case (idx, (left, right)) =>
-        ufansi.Color.Red(s"$idx | $left | $right")
-      }
-      .mkString("\n")
+  private def requirePrimaryKeys(primaryKeys: Seq[String]): Unit = {
+    require(primaryKeys.nonEmpty, primaryKeysRequiredMessage)
+  }
+
+  private def mismatchFilter(equalExpr: Column): Column = {
+    not(coalesce(equalExpr, lit(false)))
   }
 
   /**
@@ -75,18 +77,142 @@ Expected DataFrame Row Count: '$expectedCount'
   }
 
   /**
-   * Raises an error unless `actualDS` and `expectedDS` are equal. Optimized for large datasets.
+   * Raises an error unless `actualDS` and `expectedDS` are equal. Large comparisons are keyed and require non-empty `primaryKeys`.
    */
   def assertLargeDatasetEquality[T: ClassTag](
       actualDS: Dataset[T],
       expectedDS: Dataset[T],
-      equals: (T, T) => Boolean = (o1: T, o2: T) => o1.equals(o2),
+      equals: Column = defaultEqualityExpr,
       ignoreNullable: Boolean = false,
       ignoreColumnNames: Boolean = false,
       orderedComparison: Boolean = true,
       ignoreColumnOrder: Boolean = false,
-      ignoreMetadata: Boolean = true
+      ignoreMetadata: Boolean = true,
+      primaryKeys: Seq[String],
+      truncate: Int = 500
   ): Unit = {
+    assertLargeDatasetEqualityInternal(
+      actualDS,
+      expectedDS,
+      Right(equals),
+      ignoreNullable,
+      ignoreColumnNames,
+      orderedComparison,
+      ignoreColumnOrder,
+      ignoreMetadata,
+      primaryKeys,
+      truncate
+    )
+  }
+
+  /**
+   * Raises an error unless `actualDS` and `expectedDS` are equal. Large comparisons are keyed and require non-empty `primaryKeys`.
+   */
+  def assertLargeDatasetEquality[T: ClassTag](
+      actualDS: Dataset[T],
+      expectedDS: Dataset[T],
+      equals: (T, T) => Boolean,
+      primaryKeys: Seq[String]
+  ): Unit = {
+    assertLargeDatasetEqualityInternal(
+      actualDS,
+      expectedDS,
+      Left(equals),
+      ignoreNullable = false,
+      ignoreColumnNames = false,
+      orderedComparison = true,
+      ignoreColumnOrder = false,
+      ignoreMetadata = true,
+      primaryKeys,
+      truncate = 500
+    )
+  }
+
+  def assertLargeDatasetEquality[T: ClassTag](
+      actualDS: Dataset[T],
+      expectedDS: Dataset[T],
+      equals: (T, T) => Boolean,
+      ignoreNullable: Boolean,
+      ignoreColumnNames: Boolean,
+      ignoreColumnOrder: Boolean,
+      ignoreMetadata: Boolean,
+      primaryKeys: Seq[String]
+  ): Unit = {
+    assertLargeDatasetEqualityInternal(
+      actualDS,
+      expectedDS,
+      Left(equals),
+      ignoreNullable,
+      ignoreColumnNames,
+      orderedComparison = true,
+      ignoreColumnOrder,
+      ignoreMetadata,
+      primaryKeys,
+      truncate = 500
+    )
+  }
+
+  def assertLargeDatasetEquality[T: ClassTag](
+      actualDS: Dataset[T],
+      expectedDS: Dataset[T],
+      equals: (T, T) => Boolean,
+      ignoreNullable: Boolean,
+      ignoreColumnNames: Boolean,
+      orderedComparison: Boolean,
+      ignoreColumnOrder: Boolean,
+      ignoreMetadata: Boolean,
+      primaryKeys: Seq[String]
+  ): Unit = {
+    assertLargeDatasetEqualityInternal(
+      actualDS,
+      expectedDS,
+      Left(equals),
+      ignoreNullable,
+      ignoreColumnNames,
+      orderedComparison,
+      ignoreColumnOrder,
+      ignoreMetadata,
+      primaryKeys,
+      truncate = 500
+    )
+  }
+
+  def assertLargeDatasetContentEquality[T: ClassTag](
+      actualDS: Dataset[T],
+      expectedDS: Dataset[T],
+      equals: (T, T) => Boolean,
+      orderedComparison: Boolean,
+      primaryKeys: Seq[String],
+      truncate: Int = 500
+  ): Unit = {
+    implicit val datasetLike: DataFrameLike[Dataset[T], T] = SparkDatasetLike.instance[T](expectedDS.encoder)
+    assertLargeDatasetContentEqualityInternal(actualDS, expectedDS, Left(equals), orderedComparison, primaryKeys, truncate)
+  }
+
+  def assertLargeDatasetContentEquality[T: ClassTag](
+      ds1: Dataset[T],
+      ds2: Dataset[T],
+      equals: (T, T) => Boolean,
+      primaryKeys: Seq[String],
+      truncate: Int
+  ): Unit = {
+    implicit val datasetLike: DataFrameLike[Dataset[T], T] = SparkDatasetLike.instance[T](ds2.encoder)
+    assertLargeDatasetContentEqualityInternal(ds1, ds2, Left(equals), orderedComparison = true, primaryKeys, truncate)
+  }
+
+  private def assertLargeDatasetEqualityInternal[T: ClassTag](
+      actualDS: Dataset[T],
+      expectedDS: Dataset[T],
+      equals: Either[(T, T) => Boolean, Column],
+      ignoreNullable: Boolean,
+      ignoreColumnNames: Boolean,
+      orderedComparison: Boolean,
+      ignoreColumnOrder: Boolean,
+      ignoreMetadata: Boolean,
+      primaryKeys: Seq[String],
+      truncate: Int
+  ): Unit = {
+    requirePrimaryKeys(primaryKeys)
     implicit val datasetLike: DataFrameLike[Dataset[T], T] = SparkDatasetLike.instance[T](expectedDS.encoder)
     SchemaLikeComparer.assertSchemaEqual(
       datasetLike.schema(actualDS),
@@ -98,50 +224,60 @@ Expected DataFrame Row Count: '$expectedCount'
     )
 
     val actual = if (ignoreColumnOrder) orderColumnsGeneric(actualDS, expectedDS) else actualDS
-    assertLargeDatasetContentEquality(actual, expectedDS, equals, orderedComparison)
+    assertLargeDatasetContentEqualityInternal(actual, expectedDS, equals, orderedComparison, primaryKeys, truncate)
   }
 
-  def assertLargeDatasetContentEquality[T: ClassTag](
-      actualDS: Dataset[T],
-      expectedDS: Dataset[T],
-      equals: (T, T) => Boolean,
-      orderedComparison: Boolean
-  ): Unit = {
-    if (orderedComparison) {
-      assertLargeDatasetContentEquality(actualDS, expectedDS, equals)
-    } else {
-      assertLargeDatasetContentEquality(sortPreciseColumns(actualDS), sortPreciseColumns(expectedDS), equals)
-    }
-  }
-
-  def assertLargeDatasetContentEquality[T: ClassTag](ds1: Dataset[T], ds2: Dataset[T], equals: (T, T) => Boolean): Unit = {
+  private def assertLargeDatasetContentEqualityInternal[T: ClassTag](
+      ds1: Dataset[T],
+      ds2: Dataset[T],
+      equals: Either[(T, T) => Boolean, Column],
+      orderedComparison: Boolean,
+      primaryKeys: Seq[String],
+      truncate: Int
+  )(implicit datasetLike: DataFrameLike[Dataset[T], T]): Unit = {
+    requirePrimaryKeys(primaryKeys)
     try {
-      val ds1RDD = ds1.rdd.cache()
-      val ds2RDD = ds2.rdd.cache()
+      ds1.cache()
+      ds2.cache()
 
-      val actualCount   = ds1RDD.count
-      val expectedCount = ds2RDD.count
+      val actualCount   = ds1.count()
+      val expectedCount = ds2.count()
 
       if (actualCount != expectedCount) {
         throw DatasetCountMismatch(countMismatchMessage(actualCount, expectedCount))
       }
-      val expectedIndexValue = RddHelpers.zipWithIndex(ds1RDD)
-      val resultIndexValue   = RddHelpers.zipWithIndex(ds2RDD)
-      val unequalRDD = expectedIndexValue
-        .join(resultIndexValue)
-        .filter { case (_, (o1, o2)) =>
-          !equals(o1, o2)
-        }
 
-      if (!unequalRDD.isEmpty()) {
-        throw DatasetContentMismatch(
-          unequalRDDMessage(unequalRDD, maxUnequalRowsToShow)
-        )
+      val joinedDS = ds1.joinPair(ds2, primaryKeys)
+
+      val unequalDS = equals match {
+        case Left(customEquals) =>
+          joinedDS.filter((pair: (T, T)) =>
+            pair match {
+              case (null, null) => false
+              case (null, _)    => true
+              case (_, null)    => true
+              case (left, right) =>
+                !customEquals(left, right)
+            }
+          )
+        case Right(equalExpr) =>
+          joinedDS.filter(mismatchFilter(equalExpr))
       }
 
+      val unequalRows = unequalDS.take(truncate).toSeq
+      if (unequalRows.nonEmpty) {
+        val msg = "Diffs\n" ++ ProductLikeUtil.showProductDiffWithHeader(
+          Seq("Actual Content", "Expected Content"),
+          datasetLike.columns(ds1),
+          unequalRows.map(_._1),
+          unequalRows.map(_._2),
+          truncate
+        )
+        throw DatasetContentMismatch(msg)
+      }
     } finally {
-      ds1.rdd.unpersist()
-      ds2.rdd.unpersist()
+      ds1.unpersist()
+      ds2.unpersist()
     }
   }
 
@@ -153,20 +289,22 @@ Expected DataFrame Row Count: '$expectedCount'
       ignoreColumnNames: Boolean = false,
       orderedComparison: Boolean = true,
       ignoreColumnOrder: Boolean = false,
-      ignoreMetadata: Boolean = true
+      ignoreMetadata: Boolean = true,
+      primaryKeys: Seq[String]
   ): Unit = {
-    val e = (r1: Row, r2: Row) => {
+    val equals = (r1: Row, r2: Row) => {
       r1.equals(r2) || RowComparer.areRowsEqual(r1, r2, precision)
     }
     assertLargeDatasetEquality[Row](
       actualDF,
       expectedDF,
-      equals = e,
+      equals = equals,
       ignoreNullable,
       ignoreColumnNames,
       orderedComparison,
       ignoreColumnOrder,
-      ignoreMetadata
+      ignoreMetadata,
+      primaryKeys
     )
   }
 }

--- a/spark/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetUtils.scala
+++ b/spark/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetUtils.scala
@@ -1,0 +1,23 @@
+package com.github.mrpowers.spark.fast.tests
+
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.functions.col
+
+import scala.reflect.ClassTag
+
+private object DatasetUtils {
+  implicit class DatasetOps[T: ClassTag](ds: Dataset[T]) {
+    def joinPair[P: ClassTag](
+        other: Dataset[P],
+        primaryKeys: Seq[String]
+    ): Dataset[(T, P)] = {
+      ds
+        .as("l")
+        .joinWith(other.as("r"), primaryKeys.map(k => col(s"l.$k") <=> col(s"r.$k")).reduce(_ && _), "full_outer")
+        .select(
+          col("_1").as[T](ds.encoder).name("actual"),
+          col("_2").as[P](other.encoder).name("expected")
+        )
+    }
+  }
+}

--- a/spark/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/spark/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -227,7 +227,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         ),
         List(("number", IntegerType, true))
       )
-      assertLargeDataFrameEquality(sourceDF, expectedDF)
+      assertLargeDataFrameEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
     }
 
     "throws an error if the DataFrames have different schemas" in {
@@ -251,7 +251,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       )
 
       intercept[DatasetSchemaMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF)
+        assertLargeDataFrameEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       }
       intercept[DatasetSchemaMismatch] {
         assertSmallDataFrameEquality(sourceDF, expectedDF)
@@ -276,7 +276,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       )
 
       intercept[DatasetContentMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF)
+        assertLargeDataFrameEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       }
       intercept[DatasetContentMismatch] {
         assertSmallDataFrameEquality(sourceDF, expectedDF)
@@ -343,7 +343,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
           ("number", IntegerType, true)
         )
       )
-      assertLargeDataFrameEquality(sourceDF, expectedDF, ignoreColumnOrder = true)
+      assertLargeDataFrameEquality(sourceDF, expectedDF, ignoreColumnOrder = true, primaryKeys = Seq("number"))
     }
 
     "should not ignore nullable if ignoreNullable is false" in {
@@ -363,7 +363,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       )
 
       intercept[DatasetSchemaMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF)
+        assertLargeDataFrameEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       }
     }
 
@@ -422,7 +422,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         )
         .withColumn("number", col("number").as("number", new MetadataBuilder().putString("description", "small number").build()))
 
-      assertLargeDataFrameEquality(sourceDF, expectedDF)
+      assertLargeDataFrameEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
     }
 
     "can performed Dataset comparisons and compare metadata" in {
@@ -447,7 +447,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         .withColumn("number", col("number").as("number", new MetadataBuilder().putString("description", "small number").build()))
 
       intercept[DatasetSchemaMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF, ignoreMetadata = false)
+        assertLargeDataFrameEquality(sourceDF, expectedDF, ignoreMetadata = false, primaryKeys = Seq("number"))
       }
     }
 
@@ -853,121 +853,122 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
     "does nothing if the DataFrames have the same schemas and content" in {
       val sourceDF = spark.createDF(
         List(
-          1.2,
-          5.1,
-          null
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          1.2,
-          5.1,
-          null
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
+      assertApproximateLargeDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
     }
 
     "throws an error if the rows are different" in {
       val sourceDF = spark.createDF(
         List(
-          100.9,
-          5.1
+          (1, 100.9),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          1.2,
-          5.1
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      val e = intercept[DatasetContentMismatch] {
-        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+      intercept[DatasetContentMismatch] {
+        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
       }
     }
 
     "throws an error DataFrames have a different number of rows" in {
       val sourceDF = spark.createDF(
         List(
-          1.2,
-          5.1,
-          8.8
+          (1, 1.2),
+          (2, 5.1),
+          (3, 8.8)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          1.2,
-          5.1
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      val e = intercept[DatasetCountMismatch] {
-        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+      intercept[DatasetCountMismatch] {
+        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
       }
     }
 
     "should not ignore nullable if ignoreNullable is false" in {
       val sourceDF = spark.createDF(
         List(
-          1.2,
-          5.1
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, false))
+        List(("id", IntegerType, true), ("number", DoubleType, false))
       )
       val expectedDF = spark.createDF(
         List(
-          1.2,
-          5.1
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
 
       intercept[DatasetSchemaMismatch] {
-        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
       }
     }
 
     "can ignore the nullable property" in {
       val sourceDF = spark.createDF(
         List(
-          1.2,
-          5.1
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, false))
+        List(("id", IntegerType, true), ("number", DoubleType, false))
       )
       val expectedDF = spark.createDF(
         List(
-          1.2,
-          5.1
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreNullable = true)
+      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreNullable = true, primaryKeys = Seq("id"))
     }
 
     "can ignore the column names" in {
       val sourceDF = spark.createDF(
         List(
-          1.2,
-          5.1,
-          null
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("BLAHBLBH", DoubleType, true))
+        List(("id", IntegerType, true), ("BLAHBLBH", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          1.2,
-          5.1,
-          null
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreColumnNames = true)
+      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreColumnNames = true, primaryKeys = Seq("id"))
     }
 
     "can work with precision and unordered comparison" in {
@@ -982,7 +983,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         ("1", "11/01/2019", 26.76249999999991)
       ).toDF("col_B", "col_C", "col_A")
 
-      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false, primaryKeys = Seq("col_B", "col_C"))
     }
 
     "can work with precision and unordered comparison 2" in {
@@ -997,7 +998,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         ("1", "10/01/2019", 26.76249999999991, "B")
       ).toDF("col_B", "col_C", "col_A", "col_D")
 
-      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false, primaryKeys = Seq("col_B", "col_C", "col_D"))
     }
 
     "throw error when exceed precision" in {
@@ -1013,7 +1014,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       ).toDF("col_B", "col_C", "col_A")
 
       intercept[DatasetContentMismatch] {
-        assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+        assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false, primaryKeys = Seq("col_B", "col_C"))
       }
     }
 
@@ -1030,7 +1031,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       ).toDF("col_B", "col_A")
 
       intercept[DatasetContentMismatch] {
-        assertApproximateDataFrameEquality(ds1, ds2, precision = 100, orderedComparison = false)
+        assertApproximateDataFrameEquality(ds1, ds2, precision = 100, orderedComparison = false, primaryKeys = Seq("col_B"))
       }
     }
 
@@ -1047,7 +1048,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       ).toDF("col_B", "col_A")
 
       intercept[DatasetContentMismatch] {
-        assertApproximateDataFrameEquality(ds1, ds2, precision = 2, orderedComparison = false)
+        assertApproximateDataFrameEquality(ds1, ds2, precision = 2, orderedComparison = false, primaryKeys = Seq("col_B"))
       }
     }
 
@@ -1063,7 +1064,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         ("1", "10/01/2019", 26.762499999999997, Seq(26.762499999999997, 26.762499999999997))
       ).toDF("col_B", "col_C", "col_A", "col_D")
 
-      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false, primaryKeys = Seq("col_B", "col_C"))
     }
 
     "can performed Dataset comparisons and ignore metadata" in {
@@ -1087,7 +1088,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         )
         .withColumn("number", col("number").as("number", new MetadataBuilder().putString("description", "small number").build()))
 
-      assertApproximateDataFrameEquality(sourceDF, expectedDF, precision = 0.0000001)
+      assertApproximateDataFrameEquality(sourceDF, expectedDF, precision = 0.0000001, primaryKeys = Seq("number"))
     }
 
     "can performed Dataset comparisons and compare metadata" in {
@@ -1112,7 +1113,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         .withColumn("number", col("number").as("number", new MetadataBuilder().putString("description", "small number").build()))
 
       intercept[DatasetSchemaMismatch] {
-        assertApproximateDataFrameEquality(sourceDF, expectedDF, precision = 0.0000001, ignoreMetadata = false)
+        assertApproximateDataFrameEquality(sourceDF, expectedDF, precision = 0.0000001, ignoreMetadata = false, primaryKeys = Seq("number"))
       }
     }
   }

--- a/spark/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/spark/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.types._
 import SparkSessionExt._
 import com.github.mrpowers.spark.fast.tests.api.{DatasetSchemaMismatch, DatasetContentMismatch, DatasetCountMismatch}
 import com.github.mrpowers.spark.fast.tests.TestUtilsExt.ExceptionOps
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, lower}
 import org.scalatest.freespec.AnyFreeSpec
 
 object Person {
@@ -203,7 +203,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       )
 
       assertSmallDatasetEquality(sourceDF, expectedDF)
-      assertLargeDatasetEquality(sourceDF, expectedDF)
+      assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
     }
 
     "does nothing if the Datasets have the same schemas and content" in {
@@ -222,7 +222,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       )
 
       assertSmallDatasetEquality(sourceDS, expectedDS)
-      assertLargeDatasetEquality(sourceDS, expectedDS)
+      assertLargeDatasetEquality(sourceDS, expectedDS, primaryKeys = Seq("name"))
     }
 
     "works with DataFrames that have ArrayType columns" in {
@@ -248,7 +248,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         )
       )
 
-      assertLargeDatasetEquality(sourceDF, expectedDF)
+      assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       assertSmallDatasetEquality(sourceDF, expectedDF)
     }
 
@@ -307,7 +307,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       )
 
       intercept[DatasetSchemaMismatch] {
-        assertLargeDatasetEquality(sourceDF, expectedDF)
+        assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       }
 
       intercept[DatasetSchemaMismatch] {
@@ -324,10 +324,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         (10), (5), (3), (7), (1)
       ).toDF("number")
 
-      val e = intercept[DatasetContentMismatch] {
-        assertLargeDatasetEquality(sourceDF, expectedDF)
-      }
-      val e2 = intercept[DatasetContentMismatch] {
+      intercept[DatasetContentMismatch] {
         assertSmallDatasetEquality(sourceDF, expectedDF)
       }
     }
@@ -347,11 +344,8 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         )
       )
 
-      val e = intercept[DatasetContentMismatch] {
-        assertLargeDatasetEquality(sourceDS, expectedDS)
-      }
-      val e2 = intercept[DatasetContentMismatch] {
-        assertLargeDatasetEquality(sourceDS, expectedDS)
+      intercept[DatasetContentMismatch] {
+        assertLargeDatasetEquality(sourceDS, expectedDS, primaryKeys = Seq("name"))
       }
     }
 
@@ -368,7 +362,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
           Person("Alice", 5)
         )
       )
-      assertLargeDatasetEquality(sourceDS, expectedDS, Person.caseInsensitivePersonEquals)
+      assertLargeDatasetEquality(sourceDS, expectedDS, Person.caseInsensitivePersonEquals _, primaryKeys = Seq("age"))
     }
 
     "fails if custom comparator for returns false" in {
@@ -384,8 +378,8 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
           Person("Alice", 5)
         )
       )
-      val e = intercept[DatasetContentMismatch] {
-        assertLargeDatasetEquality(sourceDS, expectedDS, Person.caseInsensitivePersonEquals)
+      intercept[DatasetContentMismatch] {
+        assertLargeDatasetEquality(sourceDS, expectedDS, Person.caseInsensitivePersonEquals _, primaryKeys = Seq("age"))
       }
     }
 
@@ -411,7 +405,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         List(("number", IntegerType, true))
       )
 
-      assertLargeDatasetEquality(sourceDF, expectedDF, ignoreNullable = true)
+      assertLargeDatasetEquality(sourceDF, expectedDF, ignoreNullable = true, primaryKeys = Seq("number"))
     }
 
     "should not ignore nullable if ignoreNullable is false" in {
@@ -433,70 +427,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       )
 
       intercept[DatasetSchemaMismatch] {
-        assertLargeDatasetEquality(sourceDF, expectedDF)
-      }
-    }
-
-    "can performed unordered DataFrame comparisons" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-
-      val expectedDF = spark.createDF(
-        List(
-          (5),
-          (1)
-        ),
-        List(("number", IntegerType, true))
-      )
-
-      assertLargeDatasetEquality(sourceDF, expectedDF, orderedComparison = false)
-    }
-
-    "throws an error for unordered Dataset comparisons that don't match" in {
-      val sourceDS = spark.createDataset[Person](
-        Seq(
-          Person("bob", 1),
-          Person("frank", 5)
-        )
-      )
-
-      val expectedDS = spark.createDataset[Person](
-        Seq(
-          Person("frank", 5),
-          Person("bob", 1),
-          Person("sadie", 2)
-        )
-      )
-
-      val e = intercept[DatasetCountMismatch] {
-        assertLargeDatasetEquality(sourceDS, expectedDS, orderedComparison = false)
-      }
-    }
-
-    "throws an error for unordered DataFrame comparisons that don't match" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-      val expectedDF = spark.createDF(
-        List(
-          (5),
-          (1),
-          (10)
-        ),
-        List(("number", IntegerType, true))
-      )
-
-      val e = intercept[DatasetCountMismatch] {
-        assertLargeDatasetEquality(sourceDF, expectedDF, orderedComparison = false)
+        assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       }
     }
 
@@ -517,8 +448,8 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         List(("number", IntegerType, true))
       )
 
-      val e = intercept[DatasetCountMismatch] {
-        assertLargeDatasetEquality(sourceDF, expectedDF)
+      intercept[DatasetCountMismatch] {
+        assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       }
     }
 
@@ -543,7 +474,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
           ("number", IntegerType, true)
         )
       )
-      assertLargeDatasetEquality(sourceDF, expectedDF, ignoreColumnOrder = true)
+      assertLargeDatasetEquality(sourceDF, expectedDF, ignoreColumnOrder = true, primaryKeys = Seq("number"))
     }
 
     "can performed Dataset comparisons with unordered column" in {
@@ -561,8 +492,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         Person("alice", 5)
       ).toDS.select("age", "name").as(ds1.encoder)
 
-      assertLargeDatasetEquality(ds1, ds2, ignoreColumnOrder = true)
-      assertLargeDatasetEquality(ds2, ds1, ignoreColumnOrder = true)
+      assertLargeDatasetEquality(ds2, ds1, ignoreColumnOrder = true, primaryKeys = Seq("name"))
     }
 
     "correctly mark unequal schema field" in {
@@ -590,7 +520,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       )
 
       val e = intercept[DatasetSchemaMismatch] {
-        assertLargeDatasetEquality(sourceDF, expectedDF)
+        assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq("number"))
       }
 
       e.assertColorDiff(Seq("float", "DoubleType", "MISSING"), Seq("word", "StringType", "StructField(long,LongType,true,{})"))
@@ -615,7 +545,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         .withColumn("name", col("name").as("name", new MetadataBuilder().putString("description", "name of the individual").build()))
         .as[Person]
 
-      assertLargeDatasetEquality(ds2, ds1)
+      assertLargeDatasetEquality(ds2, ds1, primaryKeys = Seq("name"))
     }
 
     "can performed Dataset comparisons and compare metadata" in {
@@ -638,8 +568,107 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         .as[Person]
 
       intercept[DatasetSchemaMismatch] {
-        assertLargeDatasetEquality(ds2, ds1, ignoreMetadata = false)
+        assertLargeDatasetEquality(ds2, ds1, ignoreMetadata = false, primaryKeys = Seq("name"))
       }
+    }
+
+    "requires non-empty primaryKeys" in {
+      val sourceDF = Seq(
+        (1, "word"),
+        (2, "word")
+      ).toDF("id", "text")
+      val expectedDF = Seq(
+        (1, "word"),
+        (2, "word")
+      ).toDF("id", "text")
+
+      val e = intercept[IllegalArgumentException] {
+        assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq.empty)
+      }
+
+      assert(e.getMessage.contains("requires non-empty primaryKeys"))
+    }
+
+    "uses equality column expressions when comparing keyed rows" in {
+      val sourceDF = Seq(
+        (1, "bob"),
+        (2, "alice")
+      ).toDF("id", "name")
+      val expectedDF = Seq(
+        (1, "BOB"),
+        (2, "ALICE")
+      ).toDF("id", "name")
+
+      assertLargeDatasetEquality(
+        sourceDF,
+        expectedDF,
+        equals = lower(col("actual.name")) <=> lower(col("expected.name")),
+        primaryKeys = Seq("id")
+      )
+    }
+
+    "fails when primary keys are disjoint even if row counts match" in {
+      val sourceDF = Seq(
+        (1, "same"),
+        (2, "values")
+      ).toDF("id", "text")
+      val expectedDF = Seq(
+        (3, "same"),
+        (4, "values")
+      ).toDF("id", "text")
+
+      intercept[DatasetContentMismatch] {
+        assertLargeDatasetEquality(sourceDF, expectedDF, primaryKeys = Seq("id"))
+      }
+    }
+
+    "can handle when there are unmatched row of Product Type" in {
+      val sourceDS = spark.createDataset[Person](
+        Seq(
+          Person("Alice", 12),
+          Person("Bob", 17)
+        )
+      )
+
+      val expectedDS = spark.createDataset[Person](
+        Seq(
+          Person("Alice", 12),
+          Person("Bob1", 17)
+        )
+      )
+
+      intercept[DatasetContentMismatch] {
+        assertLargeDatasetEquality(
+          sourceDS,
+          expectedDS,
+          equals = (p1: Person, p2: Person) => p1.age == p2.age && p1.name == p2.name,
+          ignoreNullable = false,
+          ignoreColumnNames = false,
+          ignoreColumnOrder = false,
+          ignoreMetadata = true,
+          primaryKeys = Seq("age")
+        )
+      }
+
+    }
+
+    "can handle when there are unmatched rows of Primitive Type" in {
+      val sourceDS   = spark.range(0, 10, 1)
+      val expectedDS = spark.range(0, 20, 2)
+
+      intercept[DatasetContentMismatch] {
+        assertLargeDatasetEquality(
+          sourceDS,
+          expectedDS,
+          equals = (p1: java.lang.Long, p2: java.lang.Long) => p1 == p2,
+          ignoreNullable = false,
+          ignoreColumnNames = false,
+          ignoreColumnOrder = false,
+          ignoreMetadata = true,
+          primaryKeys = Seq("id")
+        )
+      }
+
     }
   }
 
@@ -1208,100 +1237,100 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
     "does nothing if the DataFrames have the same schemas and content" in {
       val sourceDF = spark.createDF(
         List(
-          (1.2),
-          (5.1),
-          (null)
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          (1.2),
-          (5.1),
-          (null)
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
     }
 
     "throws an error if the rows are different" in {
       val sourceDF = spark.createDF(
         List(
-          (100.9),
-          (5.1)
+          (1, 100.9),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          (1.2),
-          (5.1)
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      val e = intercept[DatasetContentMismatch] {
-        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+      intercept[DatasetContentMismatch] {
+        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
       }
     }
 
     "throws an error DataFrames have a different number of rows" in {
       val sourceDF = spark.createDF(
         List(
-          (1.2),
-          (5.1),
-          (8.8)
+          (1, 1.2),
+          (2, 5.1),
+          (3, 8.8)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          (1.2),
-          (5.1)
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      val e = intercept[DatasetCountMismatch] {
-        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01)
+      intercept[DatasetCountMismatch] {
+        assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, primaryKeys = Seq("id"))
       }
     }
 
     "can ignore the nullable property" in {
       val sourceDF = spark.createDF(
         List(
-          (1.2),
-          (5.1)
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, false))
+        List(("id", IntegerType, true), ("number", DoubleType, false))
       )
       val expectedDF = spark.createDF(
         List(
-          (1.2),
-          (5.1)
+          (1, 1.2),
+          (2, 5.1)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreNullable = true)
+      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreNullable = true, primaryKeys = Seq("id"))
     }
 
     "can ignore the column names" in {
       val sourceDF = spark.createDF(
         List(
-          (1.2),
-          (5.1),
-          (null)
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("BLAHBLBH", DoubleType, true))
+        List(("id", IntegerType, true), ("BLAHBLBH", DoubleType, true))
       )
       val expectedDF = spark.createDF(
         List(
-          (1.2),
-          (5.1),
-          (null)
+          (1, 1.2),
+          (2, 5.1),
+          (3, null)
         ),
-        List(("number", DoubleType, true))
+        List(("id", IntegerType, true), ("number", DoubleType, true))
       )
-      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreColumnNames = true)
+      assertApproximateDataFrameEquality(sourceDF, expectedDF, 0.01, ignoreColumnNames = true, primaryKeys = Seq("id"))
     }
 
     "can work with precision and unordered comparison" in {
@@ -1316,7 +1345,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         ("1", "11/01/2019", 26.76249999999991)
       ).toDF("col_B", "col_C", "col_A")
 
-      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false, primaryKeys = Seq("col_B", "col_C"))
     }
 
     "can work with precision and unordered comparison 2" in {
@@ -1331,7 +1360,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         ("1", "10/01/2019", 26.76249999999991, "B")
       ).toDF("col_B", "col_C", "col_A", "col_D")
 
-      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false, primaryKeys = Seq("col_B", "col_C", "col_D"))
     }
 
     "can work with precision and unordered comparison on nested column" in {
@@ -1346,7 +1375,7 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         ("1", "10/01/2019", 26.762499999999997, Seq(26.762499999999997, 26.762499999999997))
       ).toDF("col_B", "col_C", "col_A", "col_D")
 
-      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
+      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false, primaryKeys = Seq("col_B", "col_C"))
     }
   }
 }


### PR DESCRIPTION
Rework assertLargeDatasetEquality for Improved Usability and Performance
This PR introduces a reworked version of the assertLargeDatasetEquality API with the goal of making it more reliable, performant, and compatible with modern Spark features (e.g., Spark Connect).

Problems with the current API:
- It relies on the RDD API internally, which is slow and incompatible with Spark Connect.

- It's difficult to use correctly with large datasets spread across multiple partitions. The current implementation assumes that the expected and actual datasets are partitioned identically, which is fragile and often leads to false negatives.

Proposed Changes:
- Re-implement the API using only the DataFrame API for better performance and compatibility.

- Support both type-safe comparison and column expression-based comparison, with the latter being the default due to Spark’s optimization capabilities for SQL transformations.

- Replace the orderedComparison: Boolean flag with a more robust primaryKeys: Seq[String] parameter. Since ordering across partitions isn’t guaranteed in Spark, comparing rows by primary keys leads to more accurate and deterministic results. 

- No longer support assertLargeDatasetEquality without PrimaryKey. This is a breaking change but will enforce better Testing Habit with spark-fast-test